### PR TITLE
Documents don't have a the default 'created_at' for acts as event

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,19 @@ Development
 To contribute, you can create pull request on the official repository at
 `https://github.com/opf/openproject-documents`
 
+### Setup
+
+To be able to run specs you need to run them from the openproject root directory.  Assuming this structure:
+
+    code
+      -> openproject
+      -> openproject-documents
+
+This is how you run your specs
+
+    cd code/openproject
+    rspec ../openproject-documents
+
 Licence
 -------
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,17 @@ This is how you run your specs
     cd code/openproject
     rspec ../openproject-documents
 
+Before you can run these tests you will need to have the link the plugin in your openproject Gemfile.plugins
+
+    gem "openproject-plugins", git: "https://github.com/opf/openproject-plugins.git", :branch => "stable"
+    gem "openproject-documents", path: "../openproject-documents" 
+
+Then you need to migrate and prepare the test database
+
+    bundle
+    rake db:migrate
+    rake db:test:load
+
 Licence
 -------
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -39,6 +39,7 @@ class Document < ActiveRecord::Base
   acts_as_journalized
   acts_as_event title: Proc.new { |o| "#{Document.model_name.human}: #{o.title}" },
                 url: Proc.new { |o| { controller: '/documents', action: 'show', id: o.id } },
+                datetime: :created_on,
                 author: ( Proc.new do |o|
                             o.attachments.find(:first, order: "#{Attachment.table_name}.created_on ASC").try(:author)
                           end)

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -99,6 +99,11 @@ describe Document do
       expect(document.attachments).to be_empty
       expect(document.created_on).to eql document.updated_on
     end
+
+    it "should respond properly to the datetime request for acts-as-event" do
+      document = FactoryGirl.create(:document, project: project)
+      expect(document.event_options[:datetime]).to eql :created_on
+    end
   end
 
 end


### PR DESCRIPTION
This was causing searching in open project on a document to throw a 500 error.
