### PR TITLE
nest permissions in module

### DIFF
--- a/lib/open_project/documents/engine.rb
+++ b/lib/open_project/documents/engine.rb
@@ -46,8 +46,10 @@ module OpenProject::Documents
                           :caption => :label_document_plural,
                           :html => { :class => 'icon2 icon-book1' }
 
-      permission :manage_documents, {:documents => [:new, :create, :edit, :update, :destroy, :add_attachment]}, :require => :loggedin
-      permission :view_documents, :documents => [:index, :show, :download]
+      project_module :documents do |map|
+        permission :manage_documents, {:documents => [:new, :create, :edit, :update, :destroy, :add_attachment]}, :require => :loggedin
+        permission :view_documents, :documents => [:index, :show, :download]
+      end
 
       Redmine::Notifiable.all << Redmine::Notifiable.new('document_added')
 

--- a/spec/lib/redmine/access_control_spec.rb
+++ b/spec/lib/redmine/access_control_spec.rb
@@ -1,0 +1,51 @@
+#-- copyright
+# OpenProject Documents Plugin
+#
+# Former OpenProject Core functionality extracted into a plugin.
+#
+# Copyright (C) 2009-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+require File.dirname(__FILE__) + '/../../spec_helper'
+
+describe Redmine::AccessControl do
+
+  describe 'manage documents permission' do
+    it 'should be part of the documents project module' do
+      permission = Redmine::AccessControl.permission(:manage_documents)
+
+      expect(permission.project_module).to eql(:documents)
+    end
+  end
+
+  describe 'view documents permission' do
+    it 'should be part of the documents project module' do
+      permission = Redmine::AccessControl.permission(:view_documents)
+
+      expect(permission.project_module).to eql(:documents)
+    end
+  end
+
+end


### PR DESCRIPTION
Fixes https://www.openproject.org/work_packages/7679

Note that this will not influence existing installations of the documents plugin negatively. A role having granted such a permission before will still have it afterwards.

Proposed changelog entry:
`#7679: Permissions not nested in 'documents' project module`
