### PR TITLE
Sorting of documents within each "Sort by" group

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -44,13 +44,13 @@ class DocumentsController < ApplicationController
     documents = @project.documents
     case @sort_by
     when 'date'
-      @grouped = documents.group_by {|d| d.updated_on.to_date }
+      @grouped = documents.order('title').group_by {|d| d.updated_on.to_date }
     when 'title'
-      @grouped = documents.group_by {|d| d.title.first.upcase}
+      @grouped = documents.order('title').group_by {|d| d.title.first.upcase}
     when 'author'
-      @grouped = documents.with_attachments.group_by {|d| d.attachments.last.author}
+      @grouped = documents.order('title').with_attachments.group_by {|d| d.attachments.last.author}
     else
-      @grouped = documents.includes(:category).group_by(&:category)
+      @grouped = documents.order('title').includes(:category).group_by(&:category)
     end
     render :layout => false if request.xhr?
   end


### PR DESCRIPTION
Since enumerable list resulting from a `group_by` command is returned unsorted, the result will be documents inside each group ordered by database ID key. This is probably not what we want. 

This commit adds sorting by title within the groups. So we get a sort by selector works as follows:

**Sort by:**
- **Category** = Documents grouped and sorted by category and within each category the documents are sorted by title.
- **Date** = Documents grouped and sorted by date and within each date the documents are sorted by title.
- **Title** = Documents grouped and sorted by first letter in title and within each letter the documents are sorted by title.
- **Author** = Documents grouped and sorted by author and within each author the documents are sorted by title.
