### PR TITLE
Added event type for documents class.

### DIFF
--- a/app/models/activity/document_activity_provider.rb
+++ b/app/models/activity/document_activity_provider.rb
@@ -44,6 +44,10 @@ class Activity::DocumentActivityProvider < Activity::BaseActivityProvider
     "#{Document.model_name.human}: #{event['document_title']}"
   end
 
+  def event_type(event, activity)
+    'document'
+  end
+  
   def event_path(event, activity)
     url_helpers.project_document_path(url_helper_parameter(event))
   end


### PR DESCRIPTION
The missing event type could cause a 500 error when view the user page for a user.
Since this method was not present we got a: `UndefinedEventTypeError`
On line 131 in `base_activity_provider.rb` in OpenProject.
