### PR TITLE
fix recipient selection

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -101,7 +101,7 @@ class DocumentsController < ApplicationController
     render_attachment_warning_if_needed(@document)
 
     if attachments.present? && attachments[:files].present? && Setting.notified_events.include?('document_added')
-      users = User.find_all_by_mails(attachments[:files].first.container.recipients)
+      users = attachments[:files].first.container.recipients
       users.each do |user|
         UserMailer.attachments_added(user, attachments[:files]).deliver
       end


### PR DESCRIPTION
- `find_all_by_mails` was removed from core
- `recipients` will return users instead of their mail addresses for some time now...
