### PR TITLE
[22118] Apply new icon styling (Documents)

### DIFF
--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -34,5 +34,5 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <%= labelled_tabular_form_for @document, url: document_path(@document), method: 'PATCH' do |f| -%>
   <%= render partial: "documents/form", locals: { f: f } %>
-  <%= styled_button_tag l(:button_save), class: "-highlight -with-icon icon-yes" %>
+  <%= styled_button_tag l(:button_save), class: "-highlight -with-icon icon-checkmark" %>
 <% end %>

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -34,7 +34,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= labelled_tabular_form_for @document, url: project_documents_path(@project), html: { multipart: true } do |f| -%>
   <%= render :partial => 'documents/form', locals: { f: f } %>
   <%= render :partial => 'attachments/form' %>
-  <%= styled_button_tag l(:button_create), class: "-highlight -with-icon icon-yes" %>
+  <%= styled_button_tag l(:button_create), class: "-highlight -with-icon icon-checkmark" %>
 <% end %>
 
 

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -62,7 +62,7 @@ See doc/COPYRIGHT.rdoc for more details.
   <div class="box">
   <p><%= render :partial => 'attachments/form' %></p>
   </div>
-  <%= styled_button_tag l(:button_add), class: "-highlight -with-icon icon-yes" %>
+  <%= styled_button_tag l(:button_add), class: "-highlight -with-icon icon-checkmark" %>
 
   <% end %>
 <% end %>

--- a/lib/open_project/documents/engine.rb
+++ b/lib/open_project/documents/engine.rb
@@ -44,7 +44,7 @@ module OpenProject::Documents
                           { controller: '/documents', action: 'index' },
                           param: :project_id,
                           caption: :label_document_plural,
-                          html: { class: 'icon2 icon-book1' }
+                          html: { class: 'icon2 icon-notes' }
 
       project_module :documents do |_map|
         permission :manage_documents, {


### PR DESCRIPTION
This applies the new icon styling in the plugin. Note that this only works in combination with opf/openproject#3873 since there the icon font is updated.

https://community.openproject.org/work_packages/22118/activity
