### PR TITLE
[22803] Teaser overlaps document sub menu in sidebar 

### DIFF
--- a/app/assets/stylesheets/documents/documents.css.erb
+++ b/app/assets/stylesheets/documents/documents.css.erb
@@ -33,3 +33,7 @@ See doc/COPYRIGHT.rdoc for more details.
 dt.document:before {
   content: "\e006";
 }
+
+.sidebar--document-sort label:last-of-type {
+  margin-bottom: 2rem;
+}

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -30,6 +30,8 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
+<%= stylesheet_link_tag 'documents/documents.css' %>
+
 <%= toolbar title: l(:label_document_plural) do %>
   <% if authorize_for(:documents, :new) %>
     <li class="toolbar-item">
@@ -51,7 +53,7 @@ See doc/COPYRIGHT.rdoc for more details.
 
 <% content_for :sidebar do %>
   <h3><%= l(:label_sort_by, '') %></h3>
-  <%= form_tag({}, :method => :get) do %>
+  <%= form_tag({}, :method => :get, class: 'sidebar--document-sort') do %>
     <label>
       <%= radio_button_tag 'sort_by', 'category', (@sort_by == 'category'), :onclick => 'this.form.submit();' %>
       <%= Document.human_attribute_name(:category) %>


### PR DESCRIPTION
This increases the distance below the 'sort by'-form created by the document plugin. Thus further elements (such as the saas teaser) are not too close.

https://community.openproject.org/work_packages/22803/activity
