### PR TITLE
[22814] Documents widget on My Page cannot be removed

### DIFF
--- a/app/views/my/blocks/_documents.html.erb
+++ b/app/views/my/blocks/_documents.html.erb
@@ -30,11 +30,14 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<h3><%=l(:label_document_plural)%></h3>
-
 <% if defined? block_name %>
-  <%= content_for "#{block_name}_remove_block" %>
+  <%= content_for "#{block_name}-remove-block" %>
 <% end %>
+
+<h3 class="widget-box--header">
+  <span class="icon-context icon-notes"></span>
+  <span class="widget-box--header-title"><%=l(:label_document_plural)%></span>
+</h3>
 
 <% project_ids = @user.projects.select {|p| @user.allowed_to?(:view_documents, p)}.collect(&:id) %>
 <%= render(partial: 'documents/document',

--- a/app/views/my_projects_overviews/blocks/_documents.html.erb
+++ b/app/views/my_projects_overviews/blocks/_documents.html.erb
@@ -29,7 +29,23 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<h3><%=l(:label_document_plural)%></h3>
+
+<div class="box-actions">
+  <% if User.current.allowed_to?(:remove_block, nil, global: true) %>
+    <%= link_to_remote '', {
+          confirm: l(:label_confirm_delete),
+          url: { action: "remove_block", block: 'documents' },
+          html: { class: "icon icon-close", title: l(:button_delete) }
+        }
+        %>
+  <% end %>
+</div>
+
+<h3 class="widget-box--header">
+  <span class="icon-context icon-notes"></span>
+  <span class="widget-box--header-title"><%=l(:label_document_plural)%></span>
+</h3>
+
 
 <% if @user.allowed_to?(:view_documents, @project)%>
     <%= render(:partial => 'documents/document',


### PR DESCRIPTION
This changes the structure of block elements. Thus the remove block functionality works again. This was done for the block on myPage and project overview page.

https://community.openproject.org/work_packages/22814/activity
