### PR TITLE
[21850] Update Plugin styles for 'Nothing to display' (Documents)

### DIFF
--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -41,7 +41,7 @@ See doc/COPYRIGHT.rdoc for more details.
 <% end %>
 
 <% if @grouped.empty? %>
-  <p class="nodata"><%= l(:label_no_data) %></p>
+  <%= no_results_box %>
 <% end %>
 
 <% @grouped.keys.sort.each do |group| %>


### PR DESCRIPTION
This uses the in https://github.com/opf/openproject/pull/3665 defined new 'no results helper' in the documents plugin.

https://community.openproject.org/work_packages/21850/activity
