### PR TITLE
[22936] Documents overview is not clearly structured

### DIFF
--- a/app/assets/stylesheets/documents/documents.css.erb
+++ b/app/assets/stylesheets/documents/documents.css.erb
@@ -37,3 +37,19 @@ dt.document:before {
 .sidebar--document-sort label:last-of-type {
   margin-bottom: 2rem;
 }
+
+.document-category-elements {
+  display: inline;
+}
+
+.document-category-elements--header {
+  margin-bottom: 0.25rem;
+}
+
+.document-category-elements--date {
+  margin-bottom: 0.75rem;
+}
+
+.document-category-elements .wiki {
+  margin-bottom: 2rem;
+}

--- a/app/views/documents/_document.html.erb
+++ b/app/views/documents/_document.html.erb
@@ -30,8 +30,8 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 
-<h4><%= link_to h(document.title), :controller => '/documents', :action => 'show', :id => document %></h4>
-<p><em><%= format_time(document.updated_on) %></em></p>
+<h4 class="document-category-elements--header"><%= link_to h(document.title), :controller => '/documents', :action => 'show', :id => document %></h4>
+<p class="document-category-elements--date"><em><%= format_time(document.updated_on) %></em></p>
 
 <div class="wiki">
 	<%= format_text(truncate_lines(document.description)) %>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -47,8 +47,12 @@ See doc/COPYRIGHT.rdoc for more details.
 <% end %>
 
 <% @grouped.keys.sort.each do |group| %>
-  <h3><%= group %></h3>
-  <%= render :partial => 'documents/document', :collection => @grouped[group] %>
+  <fieldset class="form--fieldset -collapsible" onClick="toggleFieldset(this);">
+    <legend class="form--fieldset-legend"><%= group %></legend>
+    <div class="form--field document-category-elements">
+      <%= render :partial => 'documents/document', :collection => @grouped[group] %>
+    </div>
+  </fieldset>
 <% end %>
 
 <% content_for :sidebar do %>


### PR DESCRIPTION
This changes the structure and styling of the documents overview page. Thus it is easier to understand if there are many entries.

https://community.openproject.com/work_packages/22936/activity
