### PR TITLE
[20432] [Accessibility] Some form elements are pronounced with a wrong label (Documents)

### DIFF
--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -52,24 +52,28 @@ See doc/COPYRIGHT.rdoc for more details.
 <% end %>
 
 <% content_for :sidebar do %>
-  <h3><%= l(:label_sort_by, '') %></h3>
   <%= form_tag({}, :method => :get, class: 'sidebar--document-sort') do %>
-    <label>
-      <%= radio_button_tag 'sort_by', 'category', (@sort_by == 'category'), :onclick => 'this.form.submit();' %>
-      <%= Document.human_attribute_name(:category) %>
-    </label><br />
-    <label>
-      <%= radio_button_tag 'sort_by', 'date', (@sort_by == 'date'), :onclick => 'this.form.submit();' %>
-      <%= l(:label_date) %>
-    </label><br />
-    <label>
-      <%= radio_button_tag 'sort_by', 'title', (@sort_by == 'title'), :onclick => 'this.form.submit();' %>
-      <%= Document.human_attribute_name(:title) %>
-    </label><br />
-    <label>
-      <%= radio_button_tag 'sort_by', 'author', (@sort_by == 'author'), :onclick => 'this.form.submit();' %>
-      <%= Document.human_attribute_name(:author) %>
-    </label>
+    <fieldset class="form--fieldset">
+      <legend class="form--fieldset-legend"><%= l(:label_sort_by, '') %></legend>
+      <p>
+        <%= radio_button_tag 'sort_by', 'category', (@sort_by == 'category'), :onclick => 'this.form.submit();' %>
+      <label for="sort_by_category">
+        <%= Document.human_attribute_name(:category) %>
+      </label><br />
+        <%= radio_button_tag 'sort_by', 'date', (@sort_by == 'date'), :onclick => 'this.form.submit();' %>
+      <label for="sort_by_date">
+        <%= l(:label_date) %>
+      </label><br />
+        <%= radio_button_tag 'sort_by', 'title', (@sort_by == 'title'), :onclick => 'this.form.submit();' %>
+      <label for="sort_by_title">
+        <%= Document.human_attribute_name(:title) %>
+      </label><br />
+        <%= radio_button_tag 'sort_by', 'author', (@sort_by == 'author'), :onclick => 'this.form.submit();' %>
+      <label for="sort_by_author">
+        <%= Document.human_attribute_name(:author) %>
+      </label>
+      </p>
+    </fieldset>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
In opf/openproject#4283 there are fieldsets introduced in the activities sidebar filter for a better accessibility with screenreaders. This PR changes this for the document sidebar filter.

https://community.openproject.com/work_packages/20432/activity
