### PR TITLE
[23980] Add buttons are not consistently used (Documents)

### DIFF
--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -35,8 +35,12 @@ See doc/COPYRIGHT.rdoc for more details.
 <%= toolbar title: l(:label_document_plural) do %>
   <% if authorize_for(:documents, :new) %>
     <li class="toolbar-item">
-      <%= link_to({:controller => '/documents', :action => 'new', :project_id => @project}, class: 'button -alt-highlight') do %>
-        <i class="button--icon icon-add"></i> <%= l(:label_document_new) %>
+      <%= link_to({:controller => '/documents', :action => 'new', :project_id => @project},
+                  { class: 'button -alt-highlight',
+                    aria: {label: t(:label_document_new)},
+                    title: t(:label_document_new)}) do %>
+        <i class="button--icon icon-add"></i>
+        <span class="button--text"><%= t('activerecord.models.document') %></span>
       <% end %>
     </li>
   <% end %>


### PR DESCRIPTION
The makes the use of 'add' buttons consistent.

https://community.openproject.com/work_packages/23980/activity

Related PRs:
- https://github.com/finnlabs/openproject-my_project_page/pull/83
- https://github.com/finnlabs/openproject-backlogs/pull/230
- https://github.com/finnlabs/openproject-global_roles/pull/64
- https://github.com/finnlabs/openproject-meeting/pull/133
- https://github.com/finnlabs/openproject-pdf_export/pull/53
- https://github.com/opf/openproject/pull/4879
