### PR TITLE
Feature/api multiple attachment containers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.5
   Exclude:
     - db/schema.rb
 
@@ -154,7 +154,7 @@ NumericLiterals:
 OneLineConditional:
   Enabled: false
 
-OpMethod:
+BinaryOperatorParameterName:
   Enabled: false
 
 ParameterLists:
@@ -246,9 +246,6 @@ ElseLayout:
   Enabled: false
 
 HandleExceptions:
-  Enabled: false
-
-InvalidCharacterLiteral:
   Enabled: false
 
 LiteralInCondition:

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -33,16 +33,16 @@
 class Document < ActiveRecord::Base
   belongs_to :project
   belongs_to :category, class_name: "DocumentCategory", foreign_key: "category_id"
-  acts_as_attachable delete_permission: :manage_documents
+  acts_as_attachable delete_permission: :manage_documents,
+                     add_permission: :manage_documents
 
   acts_as_journalized
   acts_as_event title: Proc.new { |o| "#{Document.model_name.human}: #{o.title}" },
                 url: Proc.new { |o| { controller: '/documents', action: 'show', id: o.id } },
                 datetime: :created_on,
                 author: ( Proc.new do |o|
-                            o.attachments.find(:first, order: "#{Attachment.table_name}.created_on ASC").try(:author)
+                            o.attachments.find(:first, order: "#{Attachment.table_name}.created_at ASC").try(:author)
                           end)
-
 
   acts_as_searchable columns: ['title', "#{table_name}.description"],
                      include: :project,
@@ -79,8 +79,8 @@ class Document < ActiveRecord::Base
       # attachments has a default order that conflicts with `created_on DESC`
       # #reorder removes that default order but rather than #unscoped keeps the
       # scoping by this document
-      a = attachments.reorder('created_on DESC').first
-      @updated_on = (a && a.created_on) || created_on
+      a = attachments.reorder('created_at DESC').first
+      @updated_on = (a && a.created_at) || created_on
     end
     @updated_on
   end

--- a/lib/api/v3/attachments/attachments_by_document_api.rb
+++ b/lib/api/v3/attachments/attachments_by_document_api.rb
@@ -1,0 +1,52 @@
+#-- copyright
+# OpenProject is a project management system.
+# Copyright (C) 2012-2018 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2017 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See docs/COPYRIGHT.rdoc for more details.
+#++
+
+module API
+  module V3
+    module Attachments
+      class AttachmentsByDocumentAPI < ::API::OpenProjectAPI
+        resources :attachments do
+          helpers API::V3::Attachments::AttachmentsByContainerAPI::Helpers
+
+          helpers do
+            def container
+              document
+            end
+
+            def get_attachment_self_path
+              api_v3_paths.attachments_by_document(container.id)
+            end
+          end
+
+          get &API::V3::Attachments::AttachmentsByContainerAPI.read
+          post &API::V3::Attachments::AttachmentsByContainerAPI.create
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/documents/document_representer.rb
+++ b/lib/api/v3/documents/document_representer.rb
@@ -1,0 +1,73 @@
+#-- copyright
+# OpenProject Documents Plugin
+#
+# Former OpenProject Core functionality extracted into a plugin.
+#
+# Copyright (C) 2009-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module API
+  module V3
+    module Documents
+      class DocumentRepresenter < ::API::Decorators::Single
+        include API::Decorators::LinkedResource
+
+        self_link title_getter: ->(*) { represented.title }
+
+        link :attachments do
+          {
+            href: api_v3_paths.attachments_by_document(represented.id)
+          }
+        end
+
+        link :addAttachment do
+          next unless current_user_allowed_to(:manage_documents, context: represented.project)
+
+          {
+            href: api_v3_paths.attachments_by_document(represented.id),
+            method: :post
+          }
+        end
+
+        property :id
+
+        property :title
+
+        associated_resource :project,
+                            link: ->(*) do
+                              {
+                                href: api_v3_paths.project(represented.project.id),
+                                title: represented.project.name
+                              }
+                            end
+
+        def _type
+          'Document'
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/documents/documents_api.rb
+++ b/lib/api/v3/documents/documents_api.rb
@@ -1,0 +1,56 @@
+#-- copyright
+# OpenProject Documents Plugin
+#
+# Former OpenProject Core functionality extracted into a plugin.
+#
+# Copyright (C) 2009-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+module API
+  module V3
+    module Documents
+      class DocumentsAPI < ::API::OpenProjectAPI
+        resources :documents do
+          helpers do
+            def document
+              Document.visible.find(params[:id])
+            end
+          end
+
+          route_param :id do
+            get do
+              ::API::V3::Documents::DocumentRepresenter.new(document,
+                                                            current_user: current_user,
+                                                            embed_links: true)
+            end
+
+            mount ::API::V3::Attachments::AttachmentsByDocumentAPI
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/open_project/documents/engine.rb
+++ b/lib/open_project/documents/engine.rb
@@ -29,7 +29,6 @@
 # See doc/COPYRIGHT.rdoc for more details.
 #++
 
-
 module OpenProject::Documents
   class Engine < ::Rails::Engine
     engine_name :openproject_documents
@@ -64,6 +63,18 @@ module OpenProject::Documents
     end
 
     patches [:CustomFieldsHelper, :Project]
+
+    add_api_path :document do |id|
+      "#{root}/documents/#{id}"
+    end
+
+    add_api_path :attachments_by_document do |id|
+      "#{document(id)}/attachments"
+    end
+
+    add_api_endpoint 'API::V3::Root' do
+      mount ::API::V3::Documents::DocumentsAPI
+    end
 
     assets %w(documents/documents.css)
 

--- a/spec/api/v3/documents/document_representer_rendering_spec.rb
+++ b/spec/api/v3/documents/document_representer_rendering_spec.rb
@@ -1,0 +1,108 @@
+#-- copyright
+# OpenProject Documents Plugin
+#
+# Former OpenProject Core functionality extracted into a plugin.
+#
+# Copyright (C) 2009-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+
+describe ::API::V3::Documents::DocumentRepresenter, 'rendering' do
+  include ::API::V3::Utilities::PathHelper
+
+  let(:document) do
+    FactoryBot.build_stubbed(:document) do |wp|
+      allow(wp)
+        .to receive(:project)
+        .and_return(project)
+    end
+  end
+  let(:project) { FactoryBot.build_stubbed(:project) }
+  let(:user) { FactoryBot.build_stubbed(:user) }
+  let(:representer) do
+    described_class.create(document, current_user: user, embed_links: true)
+  end
+  let(:permissions) { all_permissions }
+  let(:all_permissions) { %i(manage_documents) }
+
+  subject { representer.to_json }
+
+  before do
+    allow(user)
+      .to receive(:allowed_to?) do |permission, project|
+      permissions.include?(permission)
+    end
+  end
+
+  describe '_links' do
+    it_behaves_like 'has a titled link' do
+      let(:link) { 'self' }
+      let(:href) { api_v3_paths.document document.id }
+      let(:title) { document.title }
+    end
+
+    it_behaves_like 'has an untitled link' do
+      let(:link) { :attachments }
+      let(:href) { api_v3_paths.attachments_by_document document.id }
+    end
+
+    it_behaves_like 'has a titled link' do
+      let(:link) { :project }
+      let(:title) { project.name }
+      let(:href) { api_v3_paths.project project.id }
+    end
+
+    it_behaves_like 'has an untitled action link' do
+      let(:link) { :addAttachment }
+      let(:href) { api_v3_paths.attachments_by_document document.id }
+      let(:method) { :post }
+      let(:permission) { :manage_documents }
+    end
+  end
+
+  describe 'properties' do
+    it_behaves_like 'property', :_type do
+      let(:value) { 'Document' }
+    end
+
+    it_behaves_like 'property', :id do
+      let(:value) { document.id }
+    end
+
+    it_behaves_like 'property', :title do
+      let(:value) { document.title }
+    end
+  end
+
+  describe '_embedded' do
+    it 'has project embedded' do
+      expect(subject)
+        .to be_json_eql(project.name.to_json)
+              .at_path('_embedded/project/name')
+    end
+  end
+end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -53,7 +53,6 @@ describe Document do
   end
 
   describe "create with a valid document" do
-
     let(:valid_document) {Document.new(title: "Test", project: project, category: documentation_category)}
 
     it "should add a document" do
@@ -69,7 +68,6 @@ describe Document do
       expect{
         valid_document.save
       }.to change{ActionMailer::Base.deliveries.size}.by 1
-
     end
 
     it "should send notifications to the recipients of the project" do
@@ -97,7 +95,7 @@ describe Document do
 
       valid_document.reload
       expect(valid_document.attachments.size).to eql 3
-      expect(valid_document.attachments.map(&:created_on).max).to eql valid_document.updated_on
+      expect(valid_document.attachments.map(&:created_at).max).to eql valid_document.updated_on
     end
 
     it "without attachments, the updated-on-date is taken from the document's date" do

--- a/spec/requests/api/v3/attachments/attachments_by_documents_resource_spec.rb
+++ b/spec/requests/api/v3/attachments/attachments_by_documents_resource_spec.rb
@@ -1,0 +1,142 @@
+#-- copyright
+# OpenProject Documents Plugin
+#
+# Former OpenProject Core functionality extracted into a plugin.
+#
+# Copyright (C) 2009-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require 'rack/test'
+
+describe 'API v3 Attachments by document resource', type: :request do
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
+  include FileHelpers
+
+  let(:current_user) do
+    FactoryBot.create(:user,
+                      member_in_project: project,
+                      member_through_role: role)
+  end
+  let(:project) { FactoryBot.create(:project) }
+  let(:role) { FactoryBot.create(:role, permissions: permissions) }
+  let(:permissions) { [:view_documents] }
+  let(:document) { FactoryBot.create(:document, project: project) }
+
+  subject(:response) { last_response }
+
+  before do
+    allow(User).to receive(:current).and_return current_user
+  end
+
+  describe '#get' do
+    let(:get_path) { api_v3_paths.attachments_by_document document.id }
+
+    before do
+      FactoryBot.create_list(:attachment, 2, container: document)
+      get get_path
+    end
+
+    it 'should respond with 200' do
+      expect(subject.status).to eq(200)
+    end
+
+    it_behaves_like 'API V3 collection response', 2, 2, 'Attachment'
+  end
+
+  describe '#post' do
+    let(:permissions) { %i[view_documents manage_documents] }
+
+    let(:request_path) { api_v3_paths.attachments_by_document document.id }
+    let(:request_parts) { { metadata: metadata, file: file } }
+    let(:metadata) { { fileName: 'cat.png' }.to_json }
+    let(:file) { mock_uploaded_file(name: 'original-filename.txt') }
+    let(:max_file_size) { 1 } # given in kiB
+
+    before do
+      allow(Setting).to receive(:attachment_max_size).and_return max_file_size.to_s
+      post request_path, request_parts
+    end
+
+    it 'should respond with HTTP Created' do
+      expect(subject.status).to eq(201)
+    end
+
+    it 'should return the new attachment' do
+      expect(subject.body).to be_json_eql('Attachment'.to_json).at_path('_type')
+    end
+
+    it 'ignores the original file name' do
+      expect(subject.body).to be_json_eql('cat.png'.to_json).at_path('fileName')
+    end
+
+    context 'metadata section is missing' do
+      let(:request_parts) { { file: file } }
+
+      it_behaves_like 'invalid request body', I18n.t('api_v3.errors.multipart_body_error')
+    end
+
+    context 'file section is missing' do
+      # rack-test won't send a multipart request without a file being present
+      # however as long as we depend on correctly named sections this test should do just fine
+      let(:request_parts) { { metadata: metadata, wrongFileSection: file } }
+
+      it_behaves_like 'invalid request body', I18n.t('api_v3.errors.multipart_body_error')
+    end
+
+    context 'metadata section is no valid JSON' do
+      let(:metadata) { '"fileName": "cat.png"' }
+
+      it_behaves_like 'parse error'
+    end
+
+    context 'metadata is missing the fileName' do
+      let(:metadata) { Hash.new.to_json }
+
+      it_behaves_like 'constraint violation' do
+        let(:message) { "fileName #{I18n.t('activerecord.errors.messages.blank')}" }
+      end
+    end
+
+    context 'file is too large' do
+      let(:file) { mock_uploaded_file(content: 'a' * 2.kilobytes) }
+      let(:expanded_localization) do
+        I18n.t('activerecord.errors.messages.file_too_large', count: max_file_size.kilobytes)
+      end
+
+      it_behaves_like 'constraint violation' do
+        let(:message) { "File #{expanded_localization}" }
+      end
+    end
+
+    context 'only allowed to view documents' do
+      let(:permissions) { [:view_documents] }
+
+      it_behaves_like 'unauthorized access'
+    end
+  end
+end

--- a/spec/requests/api/v3/documents/documents_resource_spec.rb
+++ b/spec/requests/api/v3/documents/documents_resource_spec.rb
@@ -1,0 +1,84 @@
+#-- copyright
+# OpenProject Documents Plugin
+#
+# Former OpenProject Core functionality extracted into a plugin.
+#
+# Copyright (C) 2009-2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 3.
+#
+# OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+# Copyright (C) 2006-2013 Jean-Philippe Lang
+# Copyright (C) 2010-2013 the ChiliProject Team
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+# See doc/COPYRIGHT.rdoc for more details.
+#++
+
+require 'spec_helper'
+require 'rack/test'
+
+describe 'API v3 documents resource', type: :request do
+  include Rack::Test::Methods
+  include API::V3::Utilities::PathHelper
+
+  let(:current_user) do
+    FactoryBot.create(:user, member_in_project: project, member_through_role: role)
+  end
+  let(:document) { FactoryBot.create(:document, project: project) }
+  let(:project) { FactoryBot.create(:project) }
+  let(:role) { FactoryBot.create(:role, permissions: permissions) }
+  let(:permissions) { %i(view_documents) }
+
+  subject(:response) { last_response }
+
+  before do
+    login_as(current_user)
+  end
+
+  describe 'GET /api/v3/wiki_pages/:id' do
+    let(:path) { api_v3_paths.document(document.id) }
+
+    before do
+      get path
+    end
+
+    it 'returns 200 OK' do
+      expect(subject.status)
+        .to eql(200)
+    end
+
+    it 'returns the wiki page' do
+      expect(subject.body)
+        .to be_json_eql('Document'.to_json)
+        .at_path('_type')
+
+      expect(subject.body)
+        .to be_json_eql(document.id.to_json)
+        .at_path('id')
+    end
+
+    context 'when lacking permissions' do
+      let(:permissions) { [] }
+
+      it 'returns 404 NOT FOUND' do
+        expect(subject.status)
+          .to eql(404)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Extend the API v3 with 

* GET /api/v3/documents/:id
* GET /api/v3/documents/:id/attachments
* POST /api/v3/documents/:id/attachments

in accordance with https://github.com/opf/openproject/pull/6319